### PR TITLE
updating seedless option

### DIFF
--- a/src/bs_utils/bs_utils.py
+++ b/src/bs_utils/bs_utils.py
@@ -2,14 +2,11 @@ import sys
 import numpy as np
 from numpy.random import Generator, SeedSequence, PCG64
 import hashlib
-import random
-from datetime import datetime
 
 
-
-def get_rng(seed='', verbose=False):
-    if seed is None:
-        seed = random.seed(datetime.now())
+def get_rng(seed: str = '', verbose=False):
+    if not seed:
+        seed = str(np.random.randint(1e6))
     """Generate a random number generator based on a seed string."""
     # Over python iteration the traditional hash was changed. So, here we fix it to md5
     hash = hashlib.md5(seed.encode("utf-8")).hexdigest()  # Convert string to a hash


### PR DESCRIPTION
The arg can still be `seed: str = ''` (trying to use the more modern "hints" to args)

The old comparison of `if seed is None` was always False, so it skipped that - then, the empty string was used as the string to hash - so it would actually be the same seed every time

An empty string is equivalent to False, so we can use the logic `if not seed:`, which then exposed that `random.seed(datetime.now())` does not return anything, so setting `seed = ` to that triggers a failure in the hash.

We want to return a random string, if none is provided, so that the hash can still convert it to seed the rng.  If we do not seed the random number generator, numpy has its own method to randomize, so we don't need to use datetime after all.  So I just create a seed that is a string of a random number from using numpy.random.randint, so no need to import random either.